### PR TITLE
Bug Fix

### DIFF
--- a/AbarcaJBudgetApp2/css/style.css
+++ b/AbarcaJBudgetApp2/css/style.css
@@ -30,8 +30,8 @@ h1{
 }
 
 .col-2.btn.btn-primary {
-    background-color: #7A7AFF;
-    border-color: #7A7AFF;
+    background-color: #9999FF;
+    border-color: #9999FF;
 }
 
 .col-2.btn.btn-primary:hover {

--- a/AbarcaJBudgetApp2/index.html
+++ b/AbarcaJBudgetApp2/index.html
@@ -65,16 +65,16 @@
     <div class="row mb-3">
       <div class="div" id="DisplayExpenses"></div>
     </div>
-    <div class="row">
-      <div class="div" id="injectHere"></div>
-    </div>
-    <div id="alert-toast" class="toast align-items-center" role="alert" aria-live="assertive" aria-atomic="true">
+    <div id="alert-toast" class="toast align-items-center mb-3" role="alert" aria-live="assertive" aria-atomic="true">
       <div class="d-flex justify-content-end">
         <div id="alert-toast-content" class="toast-body">
           Hello, world! This is a toast message.
         </div>
         <button type="button" class="btn-close me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
       </div>
+    </div>
+    <div class="row">
+      <div class="div" id="injectHere"></div>
     </div>
   </div>
   <!-- Optional JavaScript; choose one of the two! -->

--- a/AbarcaJBudgetApp2/scripts/app.js
+++ b/AbarcaJBudgetApp2/scripts/app.js
@@ -114,9 +114,8 @@ function CalculateRemainingBudget(userBudget, Expense) {
 }
 
 function CalculateRemainingBudgetOnStart() {
-
     //take the original budget, subtract it from the sum of the expenses
-    let userBudget = GetUserBudget();
+    budget = GetUserBudget();
     // budget = GetUserBudget(); GETTING THE BUDGET ON START MIGHT GET US CLOSE TO FIXING BUG!
     let culmulativeExpenses = GetUserExpensesFromLocalStorage();
     console.log(culmulativeExpenses);
@@ -125,12 +124,13 @@ function CalculateRemainingBudgetOnStart() {
         for (let i = 0; i < culmulativeExpenses.length; i++) {
             expensesSum += Number(culmulativeExpenses[i]);
         }
-        let remainingBudget = Number(userBudget) - expensesSum;
+        let remainingBudget = Number(budget) - expensesSum;
         BudgetDisplay.textContent = "Balance: $" + remainingBudget.toFixed(2);
+        budget = remainingBudget;
         return remainingBudget;
-    } else if (userBudget != null) {
+    } else if (budget != null) {
         //if a budget is declared but there are no expenses the budget remaining is the userBudget
-        BudgetDisplay.textContent = "Balance: $" + Number(userBudget).toFixed(2);
+        BudgetDisplay.textContent = "Balance: $" + Number(budget).toFixed(2);
     } else {
         //if a budget has yet to be declared just make it 0
         BudgetDisplay.textContent = "Balance: $" + "0.00";

--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ This is a budget mobile web application using JavaScript Local storage.
 * Error messages should be placed somewhere  else because if there are too many expenses the user will not see an error message appear!
 * Consider changing the color of the trash icon. Maybe white? Or change the background color.
 * When page is refreshed and expense is added the balance is incorrect
+    * Defining how it breaks: add expenses, remove 1. Refresh the page and then add an expense and the balance should calculate overall user budget set in the beginning - Expense = shows wrong budget

--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ This is a budget mobile web application using JavaScript Local storage.
 ## Bugs To Be Fixed
 * Error messages should be placed somewhere  else because if there are too many expenses the user will not see an error message appear!
 * Consider changing the color of the trash icon. Maybe white? Or change the background color.
+* When page is refreshed and expense is added the balance is incorrect

--- a/README.md
+++ b/README.md
@@ -3,6 +3,5 @@ This is a budget mobile web application using JavaScript Local storage.
 
 ## Bugs To Be Fixed
 * Error messages should be placed somewhere  else because if there are too many expenses the user will not see an error message appear!
-* Consider changing the color of the trash icon. Maybe white? Or change the background color.
-* When page is refreshed and expense is added the balance is incorrect
-    * Defining how it breaks: add expenses, remove 1. Refresh the page and then add an expense and the balance should calculate overall user budget set in the beginning - Expense = shows wrong budget
+* Vendors with spaced out names. Does the computer remove the right element from the DOM? Also will a long vendor name look right on a card?
+* When an expense is entered the user has to remove the input fields values for both making it slow for them. How about clearing the input's for them instead?

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ This is a budget mobile web application using JavaScript Local storage.
 
 ## Bugs To Be Fixed
 * Error messages should be placed somewhere  else because if there are too many expenses the user will not see an error message appear!
-* Consider changing the color of the trash icon. Maybe white?
+* Consider changing the color of the trash icon. Maybe white? Or change the background color.


### PR DESCRIPTION
When an expense was added and then the page was refreshed and once another expense was added the balance shown was incorrect because the initial budget was referring to the overall budget instead of the budget calculated by taking the initial budget and subtracting it from all the expenses. I also moved the error modal to the top so that it shows first so that it is not below the expenses once there are many. 