### PR TITLE
Update Expense cards

### DIFF
--- a/AbarcaJBudgetApp2/scripts/app.js
+++ b/AbarcaJBudgetApp2/scripts/app.js
@@ -1,5 +1,6 @@
 import { SaveBudgetToLocalStorage, AddAnotherExpenseToLocalStorage, AddAnotherVendorToLocalStorage, RemoveExpenseFromLocalStorage, RemoveVendorFromLocalStorage, GetUserBudget, GetVendorsFromLocalStorage, GetUserExpensesFromLocalStorage } from './localStorage.js';
 
+
 let EnterBudget = document.getElementById('EnterBudget');
 let EnterExpense = document.getElementById('EnterExpense');
 let EnterVendor = document.getElementById('EnterVendor')
@@ -7,17 +8,21 @@ let EnterBudgetBtn = document.getElementById('EnterBudgetBtn');
 let EnterExpenseBtn = document.getElementById('EnterExpenseBtn');
 let resetBtn = document.getElementById('resetBtn');
 
+
 let injectHere = document.getElementById('injectHere');
 let DisplayExpenses = document.getElementById('DisplayExpenses');
 let BudgetDisplay = document.getElementById('BudgetDisplay');
+
 
 //Connection to toast elements
 let alertToast = document.getElementById('alert-toast');
 let alertToastContent = document.getElementById('alert-toast-content');
 
+
 let budget = GetUserBudget();
 budget !== null ? EnterBudgetBtn.disabled = true : EnterBudgetBtn.disabled = false;
 budget !== null ? EnterBudget.disabled = true : EnterBudget.disabled = false;
+
 
 EnterBudgetBtn.addEventListener('click', function (e) {
     // console.log(EnterBudget.value);
@@ -42,8 +47,10 @@ EnterBudgetBtn.addEventListener('click', function (e) {
         EnterBudgetBtn.disabled = true;
         EnterBudget.disabled = true;
 
+
     }
 });
+
 
 EnterExpenseBtn.addEventListener('click', function (e) {
     //Check if there is a valid budget before the expense is added!
@@ -83,11 +90,13 @@ EnterExpenseBtn.addEventListener('click', function (e) {
         budget = CalculateRemainingBudget(budget, roundedExpense);
         DisplayOverallExpenses();
 
+
         //After the Expense and vendor is added clear it!
         EnterExpense.value = "";
         EnterVendor.value = "";
     }
 });
+
 
 //this clears local storage and refreshes the page!
 resetBtn.addEventListener('click', function () {
@@ -96,6 +105,7 @@ resetBtn.addEventListener('click', function () {
     EnterBudgetBtn.disabled = false;
     EnterBudget.disabled = false;
 });
+
 
 function DisplayOverallExpenses() {
     let sum = 0;
@@ -106,8 +116,10 @@ function DisplayOverallExpenses() {
         sum = Number(allExpenses[i]) + sum;
     }
 
+
     DisplayExpenses.textContent = "Expenses: $" + sum.toFixed(2);
 }
+
 
 function CalculateRemainingBudget(userBudget, Expense) {
     //if you do not update the original budget, it will always subtract the original budget the user entered from the expense and will be bugged!
@@ -116,6 +128,7 @@ function CalculateRemainingBudget(userBudget, Expense) {
     console.log(remainingBudget);
     return remainingBudget;
 }
+
 
 function CalculateRemainingBudgetOnStart() {
     //take the original budget, subtract it from the sum of the expenses
@@ -142,28 +155,36 @@ function CalculateRemainingBudgetOnStart() {
 }
 
 
-function CreateElement(Cost, Vendor) {
-    //check the length of the vendor!
-    let vendorTitle = CheckVendorCharacterLength(Vendor);
-    console.log(vendorTitle);
 
-    let card = document.createElement('div');
-    let cardBody = document.createElement('div');
-    let cardRow = document.createElement('row');
-    let Expense = document.createElement('div');
-    let DeleteButton = document.createElement('button');
+
+function CreateElement(Cost, Vendor) {
+    let card = document.createElement("div");
+    let cardBody = document.createElement("div");
+    let cardRow = document.createElement("row");
+    let ExpenseAndVendor = document.createElement("div");
+    let Expense = document.createElement("div");
+    let displayVendor = document.createElement("div");
+    let DeleteButton = document.createElement("button");
+
 
     card.id = Vendor + Cost;
     card.className = "card";
     cardBody.className = "card-body";
 
-    cardRow.className = "d-flex justify-content-center"
-    Expense.className = "col-6 mt-2"
-    Expense.textContent = "$" + Number(Cost).toFixed(2) + " | " + vendorTitle;
+
+    cardRow.className = "d-flex justify-content-center";
+    ExpenseAndVendor.className = "col-6 mt-2";
+    Expense.className = "col-12 d-flex justify-content-center";
+    displayVendor.className = "col-12 d-flex justify-content-center";
+    displayVendor.textContent = Vendor;
+    Expense.textContent = "$" + Number(Cost).toFixed(2);
     DeleteButton.className = "col-2 btn btn-primary";
     DeleteButton.innerHTML = "<img src=\"../images/delete.png\" width=\"28px\" height=\"29px\" alt=\"remove expense garbage can icon\">";
 
-    cardRow.appendChild(Expense);
+    //Build the card together
+    ExpenseAndVendor.appendChild(displayVendor);
+    ExpenseAndVendor.appendChild(Expense);
+    cardRow.appendChild(ExpenseAndVendor);
     cardRow.appendChild(DeleteButton);
     cardBody.appendChild(cardRow);
     card.appendChild(cardBody);
@@ -205,7 +226,6 @@ function CreateElement(Cost, Vendor) {
 
 
 
-
 function CalculateReminbursementBudget(userBudget, reimbursement) {
     //what if the user does not enter a budget or amounts on refresh, you have to do the calculations from local storage
     // let usersBudgetLocalStorage = GetUserBudget();
@@ -229,27 +249,14 @@ function CheckForLocalStorageDisplayIt() {
         CreateElement(Number(userExpenses[i]), vendors[j]);
         j++;
     }
-
     DisplayOverallExpenses();
-
 }
 
 
-function CheckVendorCharacterLength(vendorName){
-    let newName = '';
-    if(vendorName.length > 11) {
-        //When the vendor name is too long
-        newName = vendorName.slice(0, 11) + "...";
-    } else {
-        //Vendor name is fine
-        newName = vendorName;
-    }
-    return newName;
-}
-
-//resend the budget again to the like the user has to 
+//resend the budget again to the like the user has to
 
 CheckForLocalStorageDisplayIt();
 CalculateRemainingBudgetOnStart();
 BudgetDisplay.className = "DisplayTxt";
 DisplayExpenses.className = "DisplayTxt";
+

--- a/AbarcaJBudgetApp2/scripts/app.js
+++ b/AbarcaJBudgetApp2/scripts/app.js
@@ -143,6 +143,10 @@ function CalculateRemainingBudgetOnStart() {
 
 
 function CreateElement(Cost, Vendor) {
+    //check the length of the vendor!
+    let vendorTitle = CheckVendorCharacterLength(Vendor);
+    console.log(vendorTitle);
+
     let card = document.createElement('div');
     let cardBody = document.createElement('div');
     let cardRow = document.createElement('row');
@@ -155,7 +159,7 @@ function CreateElement(Cost, Vendor) {
 
     cardRow.className = "d-flex justify-content-center"
     Expense.className = "col-6 mt-2"
-    Expense.textContent = "$" + Number(Cost).toFixed(2) + " | " + Vendor;
+    Expense.textContent = "$" + Number(Cost).toFixed(2) + " | " + vendorTitle;
     DeleteButton.className = "col-2 btn btn-primary";
     DeleteButton.innerHTML = "<img src=\"../images/delete.png\" width=\"28px\" height=\"29px\" alt=\"remove expense garbage can icon\">";
 
@@ -230,6 +234,18 @@ function CheckForLocalStorageDisplayIt() {
 
 }
 
+
+function CheckVendorCharacterLength(vendorName){
+    let newName = '';
+    if(vendorName.length > 11) {
+        //When the vendor name is too long
+        newName = vendorName.slice(0, 11) + "...";
+    } else {
+        //Vendor name is fine
+        newName = vendorName;
+    }
+    return newName;
+}
 
 //resend the budget again to the like the user has to 
 

--- a/AbarcaJBudgetApp2/scripts/app.js
+++ b/AbarcaJBudgetApp2/scripts/app.js
@@ -158,6 +158,10 @@ function CalculateRemainingBudgetOnStart() {
 
 
 function CreateElement(Cost, Vendor) {
+    //figure out the Vendor name
+    let vendorName = CheckVendorNameLength(Vendor);
+
+
     let card = document.createElement("div");
     let cardBody = document.createElement("div");
     let cardRow = document.createElement("row");
@@ -176,7 +180,7 @@ function CreateElement(Cost, Vendor) {
     ExpenseAndVendor.className = "col-6 mt-2";
     Expense.className = "col-12 d-flex justify-content-center";
     displayVendor.className = "col-12 d-flex justify-content-center";
-    displayVendor.textContent = Vendor;
+    displayVendor.textContent = vendorName;
     Expense.textContent = "$" + Number(Cost).toFixed(2);
     DeleteButton.className = "col-2 btn btn-primary";
     DeleteButton.innerHTML = "<img src=\"../images/delete.png\" width=\"29px\" height=\"30px\" alt=\"remove expense garbage can icon\">";
@@ -225,7 +229,6 @@ function CreateElement(Cost, Vendor) {
 }
 
 
-
 function CalculateReminbursementBudget(userBudget, reimbursement) {
     //what if the user does not enter a budget or amounts on refresh, you have to do the calculations from local storage
     // let usersBudgetLocalStorage = GetUserBudget();
@@ -235,7 +238,6 @@ function CalculateReminbursementBudget(userBudget, reimbursement) {
     console.log(remainingBudget);
     return remainingBudget;
 }
-
 
 
 //get Local Storage when the application begins!
@@ -252,6 +254,17 @@ function CheckForLocalStorageDisplayIt() {
     DisplayOverallExpenses();
 }
 
+
+function CheckVendorNameLength(vendorName) {
+    //check the length of a vendor name 
+    let newVendorName;
+    if (vendorName.length > 18) {
+        newVendorName = vendorName.slice(0, 18) + "...";
+    } else {
+        newVendorName = vendorName;
+    }
+    return newVendorName;
+}
 
 //resend the budget again to the like the user has to
 

--- a/AbarcaJBudgetApp2/scripts/app.js
+++ b/AbarcaJBudgetApp2/scripts/app.js
@@ -179,7 +179,7 @@ function CreateElement(Cost, Vendor) {
     displayVendor.textContent = Vendor;
     Expense.textContent = "$" + Number(Cost).toFixed(2);
     DeleteButton.className = "col-2 btn btn-primary";
-    DeleteButton.innerHTML = "<img src=\"../images/delete.png\" width=\"28px\" height=\"29px\" alt=\"remove expense garbage can icon\">";
+    DeleteButton.innerHTML = "<img src=\"../images/delete.png\" width=\"29px\" height=\"30px\" alt=\"remove expense garbage can icon\">";
 
     //Build the card together
     ExpenseAndVendor.appendChild(displayVendor);

--- a/README.md
+++ b/README.md
@@ -4,5 +4,4 @@ This is a budget mobile web application using JavaScript Local storage.
 ## Bugs To Be Fixed
 * Vendors with spaced out names. Does the computer remove the right element from the DOM? Also will a long vendor name look right on a card?
 * Add a message when the user clicks on the budget input field when a budget is already declared and the Enter budget button is disabled. Show using the toast that a budget is inputted and too input another you have to use the reset button.
-* When the vendor's name is really long it causes the card to bug out and look weird. Set a character limit to the vendor!
-    * Character limit should be 14 characters and under!
+

--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ This is a budget mobile web application using JavaScript Local storage.
 * Add a message when the user clicks on the budget input field when a budget is already declared and the Enter budget button is disabled. Show using the toast that a budget is inputted and too input another you have to use the reset button.
 * When the vendor's name is really long it causes the card to bug out and look weird. Set a character limit to the vendor!
     * Character limit should be 14 characters and under!
+    * Consider chaning the layout of the card instead, to where the vendor is on top and expense is on the bottom with the delete button still on the side

--- a/README.md
+++ b/README.md
@@ -6,4 +6,3 @@ This is a budget mobile web application using JavaScript Local storage.
 * Add a message when the user clicks on the budget input field when a budget is already declared and the Enter budget button is disabled. Show using the toast that a budget is inputted and too input another you have to use the reset button.
 * When the vendor's name is really long it causes the card to bug out and look weird. Set a character limit to the vendor!
     * Character limit should be 14 characters and under!
-    * Consider chaning the layout of the card instead, to where the vendor is on top and expense is on the bottom with the delete button still on the side

--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ This is a budget mobile web application using JavaScript Local storage.
 * Vendors with spaced out names. Does the computer remove the right element from the DOM? Also will a long vendor name look right on a card?
 * Add a message when the user clicks on the budget input field when a budget is already declared and the Enter budget button is disabled. Show using the toast that a budget is inputted and too input another you have to use the reset button.
 * When the vendor's name is really long it causes the card to bug out and look weird. Set a character limit to the vendor!
+    * Character limit should be 14 characters and under!


### PR DESCRIPTION
Update the layout of the expense cards so that both the expense and the vendor have their own row but the trash icon will still be on the side of both the expense and vendor. There is now a limit to the number of characters that will be displayed for the vendor's name so that if a long vendor name is given, it will not break the layout of the card. The image of the trash can was also made larger.