### PR TITLE
Fix expense cards

### DIFF
--- a/AbarcaJBudgetApp2/css/style.css
+++ b/AbarcaJBudgetApp2/css/style.css
@@ -41,6 +41,11 @@ h1 {
     border-color: #a8a8ff;
 }
 
+.delete-btn {
+    background-color: #9999ff;
+    border-color: #9999ff;
+}
+
 .btn:disabled {
     background-color: rgb(109, 109, 109);
     border-color: rgb(109, 109, 109);

--- a/AbarcaJBudgetApp2/scripts/app.js
+++ b/AbarcaJBudgetApp2/scripts/app.js
@@ -1,5 +1,6 @@
 import { SaveBudgetToLocalStorage, AddAnotherExpenseToLocalStorage, AddAnotherVendorToLocalStorage, RemoveExpenseFromLocalStorage, RemoveVendorFromLocalStorage, GetUserBudget, GetVendorsFromLocalStorage, GetUserExpensesFromLocalStorage } from './localStorage.js';
 
+// FIXME long expenses spill onto the delete button
 
 let EnterBudget = document.getElementById('EnterBudget');
 let EnterExpense = document.getElementById('EnterExpense');

--- a/AbarcaJBudgetApp2/scripts/app.js
+++ b/AbarcaJBudgetApp2/scripts/app.js
@@ -262,7 +262,7 @@ function CheckVendorNameLength(vendorName) {
     //check the length of a vendor name 
     let newVendorName;
     if (vendorName.length > 18) {
-        newVendorName = vendorName.slice(0, 18) + "...";
+        newVendorName = vendorName.slice(0, 13) + "..."; // was (0, 18) previously
     } else {
         newVendorName = vendorName;
     }

--- a/AbarcaJBudgetApp2/scripts/app.js
+++ b/AbarcaJBudgetApp2/scripts/app.js
@@ -182,7 +182,8 @@ function CreateElement(Cost, Vendor) {
     displayVendor.className = "col-12 d-flex justify-content-center";
     displayVendor.textContent = vendorName;
     Expense.textContent = "$" + Number(Cost).toFixed(2);
-    DeleteButton.className = "col-2 btn btn-primary";
+    DeleteButton.className = "col-md-2 col-lg-2 btn btn-primary delete-btn";
+
     DeleteButton.innerHTML = "<img src=\"../images/delete.png\" width=\"29px\" height=\"30px\" alt=\"Remove Expense and Vendor button\">";
 
     //Build the card together


### PR DESCRIPTION
Create a delete button styling. Edit the column sizes for the delete button for mobile view so that the image on the garbage can is centered inside the button, and on larger screens, ensure the delete button does not get so large. Refactor the `CheckVendorNameLength` function so that long expenses names are shortened and look good on mobile screens!